### PR TITLE
fix memory leak

### DIFF
--- a/src/Data/QRCode.hsc
+++ b/src/Data/QRCode.hsc
@@ -113,7 +113,7 @@ encodeString :: String        -- ^ String to encode
              -> IO QRcode
 encodeString str version  level mode casesensitive = do
     when (null str) $ error "empty string provided"
-    newCAString str >>= \s-> encoder s version level mode casesensitive
+    withCAString str $ \s-> encoder s version level mode casesensitive
 
 encoder :: CString -> Maybe Int -> QREncodeLevel -> QREncodeMode -> Bool -> IO QRcode
 encoder cstr ver level mode casesensitive = do


### PR DESCRIPTION
use withCAString instead of newCAString
valgrind reports a leak if newCAString is used

==27848== HEAP SUMMARY:
==27848==     in use at exit: 5,139 bytes in 8 blocks
==27848==   total heap usage: 94 allocs, 86 frees, 68,854 bytes allocated
==27848== 
==27848== 6 bytes in 1 blocks are definitely lost in loss record 1 of 8
==27848==    at 0x4C28C10: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27848==    by 0x5C1D842: base_ForeignziCziString_newCAString1_info (in /usr/lib/ghc-7.10.3/base_HQfYBxpPvuw8OunzQu6JGM/libHSbase-4.8.2.0-HQfYBxpPvuw8OunzQu6JGM-ghc7.10.3.so)
==27848== 
==27848== LEAK SUMMARY:
==27848==    definitely lost: 6 bytes in 1 blocks
==27848==    indirectly lost: 0 bytes in 0 blocks
==27848==      possibly lost: 0 bytes in 0 blocks
==27848==    still reachable: 5,133 bytes in 7 blocks
==27848==         suppressed: 0 bytes in 0 blocks
==27848== Reachable blocks (those to which a pointer was found) are not shown.
==27848== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==27848== 
==27848== For counts of detected and suppressed errors, rerun with: -v
==27848== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
